### PR TITLE
Fix python_version format

### DIFF
--- a/ciscowebex.json
+++ b/ciscowebex.json
@@ -22,10 +22,7 @@
     "min_phantom_version": "6.3.0",
     "app_wizard_version": "1.0.0",
     "rest_handler": "ciscowebex_connector._handle_rest_request",
-    "python_version": [
-        "3.9",
-        "3.13"
-    ],
+    "python_version": "3.9, 3.13",
     "fips_compliant": true,
     "latest_tested_versions": [
         "Cisco webex api v1 tested on 9th May, 2025"

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,2 @@
 **Unreleased**
+* Fix python_version 3.13 format


### PR DESCRIPTION
- Fix python_version format in app JSON files from array `["3.9", "3.13"]` to string `"3.9, 3.13"`

[_Created by Sourcegraph batch change `grokas-splunk/003-fix-python-version-format`._](https://sourcegraph.splunkdev.net/users/grokas-splunk/batch-changes/003-fix-python-version-format)