### PR TITLE
fix: improve Cisco Webex validation and data handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ VARIABLE | REQUIRED | TYPE | DESCRIPTION
 **client_id** | optional | string | Client ID |
 **client_secret** | optional | password | Client Secret |
 **scope** | optional | string | Scopes (Append extra space-seperated scopes which are added during app creation from webex portal) |
+**verify_server_cert** | optional | boolean | Verify the Webex server certificate |
 
 ### Supported Actions
 
@@ -373,7 +374,6 @@ action_result.parameter.end | string | | |
 action_result.parameter.host_email | string | | |
 action_result.parameter.invitees | string | | |
 action_result.parameter.join_before_host_minutes | numeric | | |
-action_result.parameter.password | password | | |
 action_result.parameter.public_meeting | boolean | | |
 action_result.parameter.recurrence | string | | |
 action_result.parameter.reminder_time | numeric | | |
@@ -434,10 +434,6 @@ action_result.data.\*.meetingOptions.enabledChat | boolean | | True False |
 action_result.data.\*.meetingOptions.enabledFileTransfer | boolean | | True False |
 action_result.data.\*.meetingOptions.enabledVideo | boolean | | True False |
 action_result.data.\*.meetingType | string | | meetingSeries |
-action_result.data.\*.panelistPassword | string | | hhQcajkb562 |
-action_result.data.\*.password | string | | testdpXhe326 |
-action_result.data.\*.phoneAndVideoSystemPanelistPassword | string | | 44722552 |
-action_result.data.\*.phoneAndVideoSystemPassword | string | | 97237943 |
 action_result.data.\*.publicMeeting | boolean | | True False |
 action_result.data.\*.reminderTime | numeric | | 10 |
 action_result.data.\*.requireAttendeeLogin | boolean | | True False |
@@ -464,6 +460,7 @@ action_result.summary | string | | |
 action_result.message | string | | |
 summary.total_objects | numeric | | |
 summary.total_objects_successful | numeric | | |
+action_result.parameter.password | password | | |
 
 ## action: 'retrieve meeting participants'
 
@@ -683,8 +680,6 @@ action_result.data.\*.meetingOptions.enabledFileTransfer | boolean | | True Fals
 action_result.data.\*.meetingOptions.enabledVideo | boolean | | True False |
 action_result.data.\*.meetingSeriesId | string | | testa706b64041559c664a83e6btest |
 action_result.data.\*.meetingType | string | | scheduledMeeting |
-action_result.data.\*.password | string | | 72Xjx9PyYKA |
-action_result.data.\*.phoneAndVideoSystemPassword | string | | 72959979 |
 action_result.data.\*.publicMeeting | boolean | | True False |
 action_result.data.\*.reminderTime | numeric | | 15 |
 action_result.data.\*.scheduledMeetingId | string | | 937f2ef03e1a49be883320fe35fde314_20250508T140000Z |
@@ -819,7 +814,6 @@ action_result.data.\*.hostEmail | string | | example@example.com |
 action_result.data.\*.id | string | `webex recording id` | test06506faa48c790592a4198c3test |
 action_result.data.\*.meetingId | string | | test5560719471599d7test2a4c1b72_I_6547053376test |
 action_result.data.\*.meetingSeriesId | string | | test5560719471599d76418test |
-action_result.data.\*.password | string | | testpass |
 action_result.data.\*.playbackUrl | string | `url` | https://company.webex.com/siteurl/ldr.php?RCID=testcc66c2ee8536aabdd0ec607test |
 action_result.data.\*.scheduledMeetingId | string | | test60719471599d764182a4c1b7test250522T150000Z |
 action_result.data.\*.serviceType | string | | MeetingCenter |

--- a/ciscowebex.json
+++ b/ciscowebex.json
@@ -1203,10 +1203,6 @@
                     "data_type": "numeric"
                 },
                 {
-                    "data_path": "action_result.parameter.password",
-                    "data_type": "password"
-                },
-                {
                     "data_path": "action_result.parameter.public_meeting",
                     "data_type": "boolean"
                 },

--- a/ciscowebex.json
+++ b/ciscowebex.json
@@ -55,6 +55,12 @@
             "default": "spark:people_read spark:rooms_read spark:messages_write spark:rooms_write spark:memberships_write spark:messages_read meeting:participants_read meeting:schedules_read meeting:recordings_read meeting:schedules_write",
             "data_type": "string",
             "order": 4
+        },
+        "verify_server_cert": {
+            "description": "Verify the Webex server certificate",
+            "data_type": "boolean",
+            "default": true,
+            "order": 5
         }
     },
     "actions": [

--- a/ciscowebex.json
+++ b/ciscowebex.json
@@ -1814,6 +1814,10 @@
                 {
                     "data_path": "summary.total_objects_successful",
                     "data_type": "numeric"
+                },
+                {
+                    "data_path": "action_result.parameter.password",
+                    "data_type": "password"
                 }
             ],
             "render": {
@@ -3704,7 +3708,7 @@
                         "https://company.webex.com/siteurl/ldr.php?RCID=testcc66c2ee8536aabdd0ec607test"
                     ],
                     "column_name": "Playback URL",
-                    "column_order": 2,
+                    "column_order": 1,
                     "contains": [
                         "url"
                     ]
@@ -3772,7 +3776,7 @@
                         "https://company.dmz.webex.com/nbr/MultiThreadDownloadServlet?siteid=00240&recordid=197000062"
                     ],
                     "column_name": "Recording Download Link",
-                    "column_order": 3,
+                    "column_order": 2,
                     "contains": [
                         "url"
                     ]
@@ -3784,7 +3788,7 @@
                         "https://company.dmz.webex.com/nbr/MultiThreadDownloadServlet/transcript.txt?siteid=00240&recordid=197000062&confid=6547000000000001771&from=MBS"
                     ],
                     "column_name": "Transcript Download Link",
-                    "column_order": 4,
+                    "column_order": 3,
                     "contains": [
                         "url"
                     ]

--- a/ciscowebex.json
+++ b/ciscowebex.json
@@ -1634,34 +1634,6 @@
                     ]
                 },
                 {
-                    "data_path": "action_result.data.*.panelistPassword",
-                    "data_type": "string",
-                    "example_values": [
-                        "hhQcajkb562"
-                    ]
-                },
-                {
-                    "data_path": "action_result.data.*.password",
-                    "data_type": "string",
-                    "example_values": [
-                        "testdpXhe326"
-                    ]
-                },
-                {
-                    "data_path": "action_result.data.*.phoneAndVideoSystemPanelistPassword",
-                    "data_type": "string",
-                    "example_values": [
-                        "44722552"
-                    ]
-                },
-                {
-                    "data_path": "action_result.data.*.phoneAndVideoSystemPassword",
-                    "data_type": "string",
-                    "example_values": [
-                        "97237943"
-                    ]
-                },
-                {
                     "data_path": "action_result.data.*.publicMeeting",
                     "data_type": "boolean",
                     "example_values": [
@@ -3019,20 +2991,6 @@
                     ]
                 },
                 {
-                    "data_path": "action_result.data.*.password",
-                    "data_type": "string",
-                    "example_values": [
-                        "72Xjx9PyYKA"
-                    ]
-                },
-                {
-                    "data_path": "action_result.data.*.phoneAndVideoSystemPassword",
-                    "data_type": "string",
-                    "example_values": [
-                        "72959979"
-                    ]
-                },
-                {
                     "data_path": "action_result.data.*.publicMeeting",
                     "data_type": "boolean",
                     "example_values": [
@@ -3737,15 +3695,6 @@
                     "data_type": "string",
                     "example_values": [
                         "test5560719471599d76418test"
-                    ]
-                },
-                {
-                    "data_path": "action_result.data.*.password",
-                    "data_type": "string",
-                    "column_name": "Password",
-                    "column_order": 1,
-                    "example_values": [
-                        "testpass"
                     ]
                 },
                 {

--- a/ciscowebex_ai_meeting_summary.html
+++ b/ciscowebex_ai_meeting_summary.html
@@ -138,10 +138,10 @@ and limitations under the License.
                   </a>
                 </td>
                 <td>
-                  <div>{{ result.data.0.suggestedNote | default:"None" | safe }}</div>
+                  <div style="white-space: pre-wrap">{{ result.data.0.suggestedNote | default:"None" }}</div>
                 </td>
                 <td>
-                  <div>{{ result.data.0.actionItems | default:"None" | safe }}</div>
+                  <div style="white-space: pre-wrap">{{ result.data.0.actionItems | default:"None" }}</div>
                 </td>
               </tr>
             </tbody>

--- a/ciscowebex_ai_meeting_summary.html
+++ b/ciscowebex_ai_meeting_summary.html
@@ -133,7 +133,7 @@ and limitations under the License.
               <tr>
                 <td>
                   <a href="javascript:;"
-                     onclick="context_menu(this, [{'contains': ['webex recording id'], 'value': '{{ result.data.0.recordingId }}' }], 0, {{ container.id }}, null, false);">
+                     onclick="context_menu(this, [{'contains': ['webex recording id'], 'value': '{{ result.data.0.recordingId|escapejs }}' }], 0, {{ container.id }}, null, false);">
                     <span class="fa fa-caret-down">{{ result.data.0.recordingId }}</span>
                   </a>
                 </td>

--- a/ciscowebex_connector.py
+++ b/ciscowebex_connector.py
@@ -40,6 +40,14 @@ class RetVal(tuple):
         return tuple.__new__(RetVal, (val1, val2))
 
 
+def _remove_password_fields(value):
+    if isinstance(value, dict):
+        return {key: _remove_password_fields(item) for key, item in value.items() if "password" not in key.lower()}
+    if isinstance(value, list):
+        return [_remove_password_fields(item) for item in value]
+    return value
+
+
 def _get_error_message_from_exception(e, app_connector=None):
     """This function is used to get appropriate error message from the exception.
     :param e: Exception object
@@ -1036,7 +1044,7 @@ class CiscoWebexConnector(BaseConnector):
         if phantom.is_fail(ret_val):
             return action_result.get_status()
 
-        action_result.add_data(response)
+        action_result.add_data(_remove_password_fields(response))
 
         return action_result.set_status(phantom.APP_SUCCESS, "Meeting scheduled successfully")
 
@@ -1175,7 +1183,7 @@ class CiscoWebexConnector(BaseConnector):
             return action_result.get_status()
 
         # Add meeting details to action result
-        action_result.add_data(response)
+        action_result.add_data(_remove_password_fields(response))
 
         return action_result.set_status(phantom.APP_SUCCESS, "Successfully retrieved meeting details")
 
@@ -1280,9 +1288,9 @@ class CiscoWebexConnector(BaseConnector):
                 if phantom.is_fail(ret_val):
                     return action_result.get_status()
 
-                action_result.add_data(response)
+                action_result.add_data(_remove_password_fields(response))
         else:
-            action_result.add_data(response)
+            action_result.add_data(_remove_password_fields(response))
 
         return action_result.set_status(phantom.APP_SUCCESS, "Recording details retrieved successfully")
 

--- a/ciscowebex_connector.py
+++ b/ciscowebex_connector.py
@@ -17,7 +17,6 @@
 import json
 import os
 import pathlib
-import re
 import time
 import urllib.parse as urllib
 
@@ -1306,8 +1305,8 @@ class CiscoWebexConnector(BaseConnector):
                 try:
                     content = json.loads(content_str)
                     description = content.get("description", {}).get("text", "")
-                    note_items = "".join(f"<li>{note.get('text', '')}</li>" for note in content.get("notes", []))
-                    notes = f"<p>{description}</p><ul>{note_items}</ul>"
+                    note_items = [note.get("text", "") for note in content.get("notes", [])]
+                    notes = "\n".join(filter(None, [description, *note_items]))
                 except json.JSONDecodeError:
                     notes = content_str
 
@@ -1326,10 +1325,7 @@ class CiscoWebexConnector(BaseConnector):
                     content = json.loads(content_str)
                     for item in content:
                         item_content = item.get("content", "")
-                        if re.search(r"<[^>]+>", item_content):
-                            action_items += item_content
-                        else:
-                            action_items += f"<p>{item_content}</p>"
+                        action_items += f"{item_content}\n"
                 except json.JSONDecodeError:
                     action_items = content_str
 

--- a/ciscowebex_connector.py
+++ b/ciscowebex_connector.py
@@ -391,7 +391,7 @@ class CiscoWebexConnector(BaseConnector):
         return RetVal(action_result.set_status(phantom.APP_ERROR, message), None)
 
     def _make_rest_call(
-        self, endpoint, action_result, headers=None, params=None, json_data=None, data=None, files=None, method="get", verify=False
+        self, endpoint, action_result, headers=None, params=None, json_data=None, data=None, files=None, method="get", verify=True
     ):
         resp_json = None
 
@@ -480,7 +480,9 @@ class CiscoWebexConnector(BaseConnector):
         """
 
         req_url = f"{self._base_url}{consts.WEBEX_ACCESS_TOKEN_ENDPOINT}"
-        ret_val, resp_json = self._make_rest_call(action_result=action_result, endpoint=req_url, data=data, method="post")
+        ret_val, resp_json = self._make_rest_call(
+            action_result=action_result, endpoint=req_url, data=data, method="post", verify=self._verify_server_cert
+        )
         if phantom.is_fail(ret_val):
             return action_result.get_status()
 
@@ -574,6 +576,7 @@ class CiscoWebexConnector(BaseConnector):
             data=data,
             method=method,
             files=files,
+            verify=self._verify_server_cert,
         )
 
         # If token is expired, generate new token
@@ -586,7 +589,14 @@ class CiscoWebexConnector(BaseConnector):
 
             headers.update({"Authorization": f"Bearer {self._access_token}"})
             ret_val, resp_json = self._make_rest_call(
-                action_result=action_result, endpoint=endpoint, headers=headers, params=params, json_data=json_data, data=data, method=method
+                action_result=action_result,
+                endpoint=endpoint,
+                headers=headers,
+                params=params,
+                json_data=json_data,
+                data=data,
+                method=method,
+                verify=self._verify_server_cert,
             )
         if phantom.is_fail(ret_val):
             return action_result.get_status(), None
@@ -708,7 +718,7 @@ class CiscoWebexConnector(BaseConnector):
         return action_result.set_status(phantom.APP_SUCCESS)
 
     def _make_rest_call_using_api_key(
-        self, endpoint, action_result, params=None, json_data=None, data=None, files=None, method="get", verify=False
+        self, endpoint, action_result, params=None, json_data=None, data=None, files=None, method="get", verify=None
     ):
         # Create a URL to connect to
         if not endpoint.startswith("https"):
@@ -716,6 +726,9 @@ class CiscoWebexConnector(BaseConnector):
         else:
             url = endpoint
         headers = {"Authorization": f"Bearer {self._api_key}"}
+
+        if verify is None:
+            verify = self._verify_server_cert
 
         return self._make_rest_call(
             url, action_result, params=params, headers=headers, json_data=json_data, data=data, method=method, verify=verify, files=files
@@ -1464,6 +1477,7 @@ class CiscoWebexConnector(BaseConnector):
         config = self.get_config()
         self._base_url = consts.BASE_URL
         self._api_key = config.get("authorization_key", None)
+        self._verify_server_cert = config.get("verify_server_cert", True)
 
         self._client_id = config.get(consts.WEBEX_STR_CLIENT_ID, None)
         self._client_secret = config.get(consts.WEBEX_STR_SECRET, None)

--- a/ciscowebex_connector.py
+++ b/ciscowebex_connector.py
@@ -999,7 +999,9 @@ class CiscoWebexConnector(BaseConnector):
     def _handle_schedule_meeting(self, param):
         """Schedules a Webex meeting based on provided parameters."""
         self.save_progress(f"In action handler for: {self.get_action_identifier()}")
-        action_result = self.add_action_result(ActionResult(dict(param)))
+        result_param = dict(param)
+        result_param.pop("password", None)
+        action_result = self.add_action_result(ActionResult(result_param))
 
         # Required parameters
         title = param.get("title")

--- a/ciscowebex_connector.py
+++ b/ciscowebex_connector.py
@@ -371,8 +371,10 @@ class CiscoWebexConnector(BaseConnector):
 
         if hasattr(action_result, "add_debug_data"):
             action_result.add_debug_data({"r_status_code": r.status_code})
-            action_result.add_debug_data({"r_text": r.text})
-            action_result.add_debug_data({"r_headers": r.headers})
+            request_url = getattr(getattr(r, "request", None), "url", "")
+            if not request_url.endswith(consts.WEBEX_ACCESS_TOKEN_ENDPOINT):
+                action_result.add_debug_data({"r_text": r.text})
+                action_result.add_debug_data({"r_headers": r.headers})
 
         # Process each 'Content-Type' of response separately
 

--- a/ciscowebex_connector.py
+++ b/ciscowebex_connector.py
@@ -1120,6 +1120,7 @@ class CiscoWebexConnector(BaseConnector):
         message_id = param.get("message_id")
         if not message_id:
             return action_result.set_status(phantom.APP_ERROR, "Missing required parameter: message_id")
+        message_id = urllib.quote(str(message_id), safe="")
 
         # Call the Webex API
         if self._api_key:

--- a/ciscowebex_connector.py
+++ b/ciscowebex_connector.py
@@ -14,9 +14,11 @@
 # and limitations under the License.
 #
 #
+import hmac
 import json
 import os
 import pathlib
+import secrets
 import time
 import urllib.parse as urllib
 
@@ -85,8 +87,9 @@ def _handle_rest_request(request, path_parts):
     # To handle response from Webex login page
     if call_type == "result":
         return_val = _handle_login_response(request)
-        asset_id = request.GET.get("state")  # nosemgrep
-        if asset_id and asset_id.isalnum():
+        oauth_state = request.GET.get("state", "")
+        asset_id, separator, _nonce = oauth_state.partition(".")
+        if return_val.status_code == 200 and separator and asset_id.isalnum():
             app_dir = pathlib.Path(__file__).resolve()
             auth_status_file_path = app_dir.with_name("{}_{}".format(asset_id, "oauth_task.out"))
             real_auth_status_file_path = os.path.abspath(auth_status_file_path)
@@ -105,11 +108,17 @@ def _handle_login_response(request):
     :return: HttpResponse. The response displayed on authorization URL page
     """
 
-    asset_id = request.GET.get("state")
-    if not asset_id:
+    oauth_state = request.GET.get("state", "")
+    asset_id, separator, _nonce = oauth_state.partition(".")
+    if not separator or not asset_id.isalnum():
         return HttpResponse(  # nosemgrep
-            f"ERROR: Asset ID not found in URL\n{json.dumps(request.GET)}", content_type=consts.WEBEX_STR_TEXT, status=400
+            "ERROR: Invalid OAuth state", content_type=consts.WEBEX_STR_TEXT, status=400
         )
+
+    state = _load_app_state(asset_id)
+    expected_oauth_state = state.get(consts.WEBEX_STR_OAUTH_STATE)
+    if not expected_oauth_state or not hmac.compare_digest(oauth_state, expected_oauth_state):
+        return HttpResponse("ERROR: Invalid OAuth state", content_type=consts.WEBEX_STR_TEXT, status=400)  # nosemgrep
 
     # Check for error in URL
     error = request.GET.get("error")
@@ -130,7 +139,7 @@ def _handle_login_response(request):
             f"Error while authenticating\n{json.dumps(request.GET)}", content_type=consts.WEBEX_STR_TEXT, status=400
         )
 
-    state = _load_app_state(asset_id)
+    state.pop(consts.WEBEX_STR_OAUTH_STATE, None)
     state[consts.WEBEX_STR_CODE] = code
     _save_app_state(state, asset_id, None)
 
@@ -639,8 +648,10 @@ class CiscoWebexConnector(BaseConnector):
             return action_result.set_status(phantom.APP_ERROR, error_message)
 
         # Authorization URL used to make request for getting code which is used to generate access token
+        oauth_state = f"{self._asset_id}.{secrets.token_urlsafe(32)}"
+        app_state[consts.WEBEX_STR_OAUTH_STATE] = oauth_state
         authorization_url = consts.AUTHORIZATION_URL.format(
-            client_id=self._client_id, redirect_uri=redirect_uri, response_type=consts.WEBEX_STR_CODE, state=self._asset_id, scope=self._scopes
+            client_id=self._client_id, redirect_uri=redirect_uri, response_type=consts.WEBEX_STR_CODE, state=oauth_state, scope=self._scopes
         )
 
         authorization_url = f"{self._base_url}{authorization_url}"

--- a/ciscowebex_consts.py
+++ b/ciscowebex_consts.py
@@ -34,6 +34,7 @@ WEBEX_STR_GRANT_TYPE = "grant_type"
 WEBEX_STR_REDIRECT_URI = "redirect_uri"
 WEBEX_STR_IS_ENCRYPTED = "is_encrypted"
 WEBEX_STR_SCOPE = "scope"
+WEBEX_STR_OAUTH_STATE = "oauth_state"
 WEBEX_JSON_HEADERS = {"Content-Type": "application/json"}
 
 WEBEX_SUCCESS_CODE_RECEIVED_MESSAGE = "Code received. Please close this window, the action will continue to get new token"

--- a/ciscowebex_get_recording_details.html
+++ b/ciscowebex_get_recording_details.html
@@ -132,7 +132,7 @@ and limitations under the License.
                 <tr>
                   <td>
                     <a href="javascript:;"
-                       onclick="context_menu(this, [{'contains': ['webex recording id'], 'value': '{{ item.id }}' }], 0, {{ container.id }}, null, false);">
+                       onclick="context_menu(this, [{'contains': ['webex recording id'], 'value': '{{ item.id|escapejs }}' }], 0, {{ container.id }}, null, false);">
                       <span class="fa fa-caret-down">{{ item.id }}</span>
                     </a>
                   </td>

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -5,3 +5,4 @@
 - Rendered AI meeting summaries as escaped plain text instead of trusted upstream HTML.
 - Bound OAuth callbacks to a single-use, cryptographically random state value.
 - URL-encoded message identifiers before inserting them into Webex API paths.
+- Excluded OAuth token responses from action-result diagnostic data.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,10 +1,10 @@
 **Unreleased**
 
-* - Enabled Webex server certificate verification by default and added an asset setting to control it.
-* - Escaped recording identifiers before inserting them into widget JavaScript contexts.
-* - Rendered AI meeting summaries as escaped plain text instead of trusted upstream HTML.
-* - Bound OAuth callbacks to a single-use, cryptographically random state value.
-* - URL-encoded message identifiers before inserting them into Webex API paths.
-* - Excluded OAuth token responses from action-result diagnostic data.
-* - Prevented schedule-meeting input passwords from being persisted in action parameters.
-* - Removed meeting and recording password fields from stored action results.
+* Enabled Webex server certificate verification by default and added an asset setting to control it.
+* Escaped recording identifiers before inserting them into widget JavaScript contexts.
+* Rendered AI meeting summaries as escaped plain text instead of trusted upstream HTML.
+* Bound OAuth callbacks to a single-use, cryptographically random state value.
+* URL-encoded message identifiers before inserting them into Webex API paths.
+* Excluded OAuth token responses from action-result diagnostic data.
+* Prevented schedule-meeting input passwords from being persisted in action parameters.
+* Removed meeting and recording password fields from stored action results.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,10 +1,10 @@
 **Unreleased**
 
-- Enabled Webex server certificate verification by default and added an asset setting to control it.
-- Escaped recording identifiers before inserting them into widget JavaScript contexts.
-- Rendered AI meeting summaries as escaped plain text instead of trusted upstream HTML.
-- Bound OAuth callbacks to a single-use, cryptographically random state value.
-- URL-encoded message identifiers before inserting them into Webex API paths.
-- Excluded OAuth token responses from action-result diagnostic data.
-- Prevented schedule-meeting input passwords from being persisted in action parameters.
-- Removed meeting and recording password fields from stored action results.
+* - Enabled Webex server certificate verification by default and added an asset setting to control it.
+* - Escaped recording identifiers before inserting them into widget JavaScript contexts.
+* - Rendered AI meeting summaries as escaped plain text instead of trusted upstream HTML.
+* - Bound OAuth callbacks to a single-use, cryptographically random state value.
+* - URL-encoded message identifiers before inserting them into Webex API paths.
+* - Excluded OAuth token responses from action-result diagnostic data.
+* - Prevented schedule-meeting input passwords from being persisted in action parameters.
+* - Removed meeting and recording password fields from stored action results.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -6,3 +6,4 @@
 - Bound OAuth callbacks to a single-use, cryptographically random state value.
 - URL-encoded message identifiers before inserting them into Webex API paths.
 - Excluded OAuth token responses from action-result diagnostic data.
+- Prevented schedule-meeting input passwords from being persisted in action parameters.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -7,3 +7,4 @@
 - URL-encoded message identifiers before inserting them into Webex API paths.
 - Excluded OAuth token responses from action-result diagnostic data.
 - Prevented schedule-meeting input passwords from being persisted in action parameters.
+- Removed meeting and recording password fields from stored action results.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,4 @@
 **Unreleased**
 
 - Enabled Webex server certificate verification by default and added an asset setting to control it.
+- Escaped recording identifiers before inserting them into widget JavaScript contexts.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -4,3 +4,4 @@
 - Escaped recording identifiers before inserting them into widget JavaScript contexts.
 - Rendered AI meeting summaries as escaped plain text instead of trusted upstream HTML.
 - Bound OAuth callbacks to a single-use, cryptographically random state value.
+- URL-encoded message identifiers before inserting them into Webex API paths.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+- Enabled Webex server certificate verification by default and added an asset setting to control it.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -3,3 +3,4 @@
 - Enabled Webex server certificate verification by default and added an asset setting to control it.
 - Escaped recording identifiers before inserting them into widget JavaScript contexts.
 - Rendered AI meeting summaries as escaped plain text instead of trusted upstream HTML.
+- Bound OAuth callbacks to a single-use, cryptographically random state value.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -2,3 +2,4 @@
 
 - Enabled Webex server certificate verification by default and added an asset setting to control it.
 - Escaped recording identifiers before inserting them into widget JavaScript contexts.
+- Rendered AI meeting summaries as escaped plain text instead of trusted upstream HTML.


### PR DESCRIPTION
## Summary

- enable Webex TLS certificate verification by default
- harden widget rendering and OAuth callback state handling
- encode message path segments and exclude OAuth tokens from diagnostics
- prevent meeting and recording passwords from entering stored action results

## Tracking

- [PAPP-38126](https://splunk.atlassian.net/browse/PAPP-38126)
- [PSAAS-30619](https://splunk.atlassian.net/browse/PSAAS-30619)
- [PSAAS-30817](https://splunk.atlassian.net/browse/PSAAS-30817)
- [PSAAS-30997](https://splunk.atlassian.net/browse/PSAAS-30997)
- [PSAAS-31084](https://splunk.atlassian.net/browse/PSAAS-31084)
- [PSAAS-31151](https://splunk.atlassian.net/browse/PSAAS-31151)
- [PSAAS-31897](https://splunk.atlassian.net/browse/PSAAS-31897)
- [PSAAS-32162](https://splunk.atlassian.net/browse/PSAAS-32162)
- [PSAAS-32410](https://splunk.atlassian.net/browse/PSAAS-32410)

## Quality gate

- pre-commit run --all-files
- Python source compilation

Created with Codex AI assistance.

## Tracking

- PAPP: PAPP-38126
- PSAAS: PSAAS-30619, PSAAS-30817, PSAAS-30997, PSAAS-31084, PSAAS-31151, PSAAS-31897, PSAAS-32162, PSAAS-32410
- Written by Codex.

## Release impact

This PR contains a breaking configuration change and must ship as a major release. Cisco Webex now verifies server certificates by default; existing assets must trust the server certificate chain or explicitly disable verification. The corresponding functional commit includes a parseable `BREAKING CHANGE:` trailer for semantic-release.

Merge strategy: merge commit only; do not squash

Release-impact note added by Codex.